### PR TITLE
#932 and #901, Reset/Forgot password and password updated styled emails 

### DIFF
--- a/email/html/event-update_password.ftl
+++ b/email/html/event-update_password.ftl
@@ -1,0 +1,20 @@
+<#import "template/body.ftl" as body>
+<#import "template/button.ftl" as button>
+<#import "template/layout.ftl" as layout>
+<#import "template/text.ftl" as text>
+
+<#--  EMAIL - Update password confirmation -->
+
+<@layout.emailLayout title=msg("eventUpdatePasswordSubject")>
+  <#--  ENGLISH  -->
+  <@body.emailBody_en title=msg("eventUpdatePassword_title_en")>
+    <@text.emailText><b>${msg("eventUpdatePassword_welcome_en")}</b></@text.emailText>
+    <@text.emailText>${msg("eventUpdatePassword_text_en")?no_esc}</@text.emailText>
+  </@body.emailBody_en>
+
+  <#--  FRENCH  -->
+  <@body.emailBody_fr title=msg("eventUpdatePassword_title_fr")>
+    <@text.emailText><b>${msg("eventUpdatePassword_welcome_fr")}</b></@text.emailText>
+    <@text.emailText>${msg("eventUpdatePassword_text_fr")?no_esc}</@text.emailText>
+  </@body.emailBody_fr>
+</@layout.emailLayout>

--- a/email/html/password-reset.ftl
+++ b/email/html/password-reset.ftl
@@ -1,0 +1,24 @@
+<#import "template/body.ftl" as body>
+<#import "template/button.ftl" as button>
+<#import "template/layout.ftl" as layout>
+<#import "template/text.ftl" as text>
+
+<#--  EMAIL - password reset -->
+
+<@layout.emailLayout title=msg("passwordResetSubject")>
+  <#--  ENGLISH  -->
+  <@body.emailBody_en title=msg("passwordReset_title_en")>
+    <@text.emailText><b>${msg("passwordReset_welcome_en")}</b></@text.emailText>
+    <@text.emailText>${msg("passwordReset_text_en")?no_esc}</@text.emailText>
+    <@button.emailButton link=link>${msg("passwordReset_button_en")}</@button.emailButton>
+    <@text.emailText>${msg("passwordReset_expiry_en", linkExpirationFormatter(linkExpiration))?no_esc}</@text.emailText>
+  </@body.emailBody_en>
+
+  <#--  FRENCH  -->
+  <@body.emailBody_fr title=msg("passwordReset_title_fr")>
+    <@text.emailText><b>${msg("passwordReset_welcome_fr")}</b></@text.emailText>
+    <@text.emailText>${msg("passwordReset_text_fr")?no_esc}</@text.emailText>
+    <@button.emailButton link=link>${msg("passwordReset_button_fr")}</@button.emailButton>
+    <@text.emailText>${msg("passwordReset_expiry_fr", linkExpirationFormatter(linkExpiration))?no_esc}</@text.emailText>
+  </@body.emailBody_fr>
+</@layout.emailLayout>

--- a/email/messages/messages_en.properties
+++ b/email/messages/messages_en.properties
@@ -8,6 +8,7 @@
 # Keys: these come from Keycloak Java code, don't change them.
 # Values: must be bilingual, English / French
 emailVerificationSubject=Please Verify Your Email Address / Veuillez vérifier votre adresse e-mail
+passwordResetSubject=Reset password / Réinitialiser le mot de passe
 
 # COMMON
 
@@ -46,3 +47,18 @@ emailVer_welcome_fr=Welcome to the OHCRN Registry! FRENCH
 # TODO change these from 1 long HTML string to several strings
 emailVerificationBody=Someone has created a {2} account with this email address. If this was you, click the link below to verify your email address\n\n{0}\n\nThis link will expire within {3}.\n\nIf you didn''t create this account, just ignore this message.
 emailVerificationBodyHtml=<p>Someone has created a {2} account with this email address. If this was you, click the link below to verify your email address</p><p><a href="{0}">Link to e-mail address verification</a></p><p>This link will expire within {3}.</p><p>If you didn''t create this account, just ignore this message.</p>
+
+## PASSWORD RESET 
+passwordReset_title_en=Forgot Password
+passwordReset_title_fr=Mot de passe oublié
+passwordReset_welcome_en=Hello, 
+passwordReset_welcome_fr=Bonjour,
+passwordReset_text_en=<p>We received a request to reset your password.</p><p>Please click the button below and follow the steps to reset your password.</p>
+passwordReset_text_fr=<p>Nous avons reçu une demande de réinitialisation de votre mot de passe.</p><p>Veuillez cliquer sur le bouton ci-dessous et suivre les étapes pour réinitialiser votre mot de passe.</p>
+passwordReset_button_en=Reset Password
+passwordReset_button_fr=Réinitialiser le mot de passe
+passwordReset_expiry_en=<p>This link will expire in {0}.</p><p>If you didn''t make this request please ignore this email.</p>
+passwordReset_expiry_fr=<p>Ce lien expirera dans {0}.</p><p>Si vous n''avez pas fait cette demande, veuillez ignorer cet e-mail.</p>
+
+
+

--- a/email/messages/messages_en.properties
+++ b/email/messages/messages_en.properties
@@ -9,6 +9,7 @@
 # Values: must be bilingual, English / French
 emailVerificationSubject=Please Verify Your Email Address / Veuillez vérifier votre adresse e-mail
 passwordResetSubject=Reset password / Réinitialiser le mot de passe
+eventUpdatePasswordSubject=Update password / Mise à jour du mot de passe
 
 # COMMON
 
@@ -53,12 +54,18 @@ passwordReset_title_en=Forgot Password
 passwordReset_title_fr=Mot de passe oublié
 passwordReset_welcome_en=Hello, 
 passwordReset_welcome_fr=Bonjour,
-passwordReset_text_en=<p>We received a request to reset your password.</p><p>Please click the button below and follow the steps to reset your password.</p>
-passwordReset_text_fr=<p>Nous avons reçu une demande de réinitialisation de votre mot de passe.</p><p>Veuillez cliquer sur le bouton ci-dessous et suivre les étapes pour réinitialiser votre mot de passe.</p>
+passwordReset_text_en=We received a request to reset your password.<br/>Please click the button below and follow the steps to reset your password.
+passwordReset_text_fr=<p>Nous avons reçu une demande de réinitialisation de votre mot de passe.<br/>Veuillez cliquer sur le bouton ci-dessous et suivre les étapes pour réinitialiser votre mot de passe.
 passwordReset_button_en=Reset Password
 passwordReset_button_fr=Réinitialiser le mot de passe
-passwordReset_expiry_en=<p>This link will expire in {0}.</p><p>If you didn''t make this request please ignore this email.</p>
-passwordReset_expiry_fr=<p>Ce lien expirera dans {0}.</p><p>Si vous n''avez pas fait cette demande, veuillez ignorer cet e-mail.</p>
+passwordReset_expiry_en=<p>This link will expire in {0}.<br/>If you didn''t make this request please ignore this email.
+passwordReset_expiry_fr=<p>Ce lien expirera dans {0}.<br/>Si vous n''avez pas fait cette demande, veuillez ignorer cet e-mail.
 
-
+## UPDATE PASSWORD CONFIRMATION
+eventUpdatePassword_title_en= Update Password
+eventUpdatePassword_title_fr= Mise à jour du mot de passe
+eventUpdatePassword_welcome_en=Hello,
+eventUpdatePassword_welcome_fr=Bonjour,
+eventUpdatePassword_text_en=<p>Your password has been successfully changed.</p><p>If this request was not made by you please contact us at <a href= "mailto: info@ohcrn.ca"> info@ohcrn.ca </a> as soon as possible.</p>
+eventUpdatePassword_text_fr=<p>Votre mot de passe a été modifié avec succès.</p><p>Si cette demande n''a pas été faite par vous, veuillez nous contacter à <a href= "mailto: info@ohcrn.ca"> info@ohcrn.ca </a>dès que possible.</p>
 

--- a/email/text/event-update_password.ftl
+++ b/email/text/event-update_password.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventUpdatePasswordBody",event.date, event.ipAddress)}

--- a/email/text/password-reset.ftl
+++ b/email/text/password-reset.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("passwordResetBody",link, linkExpiration, realmName, linkExpirationFormatter(linkExpiration))}

--- a/email/theme.properties
+++ b/email/theme.properties
@@ -1,3 +1,4 @@
+parent=base
 # for keycloak - don't edit keys
 locales=en
 


### PR DESCRIPTION
# Description 
This PR creates a styled template for reset/forgot password emails and update password confirmation emails in keycloak. 
Mockups found here
-[Reset/Forgot password]( https://www.figma.com/design/uft9F45tddCba46xnL4Tfg/OHCRN%2FDev%2FMVP?node-id=4773-17030&node-type=frame&t=BeyoH50W8lx0N2dn-0)
-[Password Updated Confirmation](https://www.figma.com/design/uft9F45tddCba46xnL4Tfg/OHCRN%2FDev%2FMVP?node-id=4773-17784&node-type=frame&t=BeyoH50W8lx0N2dn-0)

## Changes 
- Added `password-reset` template 
- Added english and french text to `messages_en.properties` for `password-reset` template 
- Added `event-update_password` template 
- Added english and french text to `messages_en.properties` for `event-update_password` template 

## Testing instructions:

- Copy the entire theme folder into Keycloak: docker cp ./keycloak-theme KEYCLOAK_CONTAINER_ID:/opt/bitnami/keycloak/themes
- Configure email theme in Keycloak admin.
- Click login from consent portal and click **Forgot Password**
- Enter an email for a user 
- Check Mailhog for your **Reset password / Réinitialiser le mot de passe** email
- Click the link to reset the password 
- Check Mailhog for your **Update password / Mise à jour du mot de passe**