### PR TITLE
🐛 Updated link to href for password-reset

### DIFF
--- a/email/html/password-reset.ftl
+++ b/email/html/password-reset.ftl
@@ -10,7 +10,7 @@
   <@body.emailBody_en title=msg("passwordReset_title_en")>
     <@text.emailText><b>${msg("passwordReset_welcome_en")}</b></@text.emailText>
     <@text.emailText>${msg("passwordReset_text_en")?no_esc}</@text.emailText>
-    <@button.emailButton link=link>${msg("passwordReset_button_en")}</@button.emailButton>
+    <@button.emailButton href=link>${msg("passwordReset_button_en")}</@button.emailButton>
     <@text.emailText>${msg("passwordReset_expiry_en", linkExpirationFormatter(linkExpiration))?no_esc}</@text.emailText>
   </@body.emailBody_en>
 
@@ -18,7 +18,7 @@
   <@body.emailBody_fr title=msg("passwordReset_title_fr")>
     <@text.emailText><b>${msg("passwordReset_welcome_fr")}</b></@text.emailText>
     <@text.emailText>${msg("passwordReset_text_fr")?no_esc}</@text.emailText>
-    <@button.emailButton link=link>${msg("passwordReset_button_fr")}</@button.emailButton>
+    <@button.emailButton href=link>${msg("passwordReset_button_fr")}</@button.emailButton>
     <@text.emailText>${msg("passwordReset_expiry_fr", linkExpirationFormatter(linkExpiration))?no_esc}</@text.emailText>
   </@body.emailBody_fr>
 </@layout.emailLayout>


### PR DESCRIPTION
# Description
We found a bug related to Forgot Password when logging in with Keycloak. After a user submits a forgot password request: 
![image](https://github.com/user-attachments/assets/72146b65-e674-4521-8e9f-b1e7f76f759d), the UI displayed an error message: 
![image](https://github.com/user-attachments/assets/b1654b4e-3e15-4705-a225-143e04477c68)

@mistryrn checked the keycloak pod logs and the `emailButton` had an invalid prop `link`. 

We have updated it to `href`.

# Testing Instructions
`. Copy the entire theme folder into Keycloak: `docker cp ./keycloak-theme KEYCLOAK_CONTAINER_ID:/opt/bitnami/keycloak/themes`
2. Click login from OHCRN
3. Submit a forgot password request
