### PR TITLE
#1031: move email images to consent UI

### DIFF
--- a/email/theme.properties
+++ b/email/theme.properties
@@ -6,7 +6,7 @@ locales=en
 
 ## images
 bannerVerify=ohcrn-email_banner-verify.jpg
-baseImageUrl=${env.KEYCLOAK_EMAIL_IMAGE_BASE_URL:http://localhost:8087/img/}
+baseImageUrl=${env.KEYCLOAK_EMAIL_IMAGE_BASE_URL:http://localhost:3000/assets/images/emails/}
 iconAbout=ohcrn-email_about.png
 iconContact=ohcrn-email_contact.png
 iconHelp=ohcrn-email_help.png


### PR DESCRIPTION
## Ticket
- https://github.com/OHCRN/platform/issues/1031

## Description

This PR updates the default base URL for images to be the localhost URL for consent UI. 

Requires changes from https://github.com/OHCRN/platform/pull/1079, updating the .env file at the root of the platform repo, and re-initializing keycloak.