### PR TITLE
💄 728 - Styling changes for update password flow

### DIFF
--- a/login/login-update-password.ftl
+++ b/login/login-update-password.ftl
@@ -1,0 +1,68 @@
+<#import "template.ftl" as layout>
+<#import "password-commons.ftl" as passwordCommons>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm'); section>
+    <#if section = "header">
+        ${msg("updatePasswordTitle")}
+    <#elseif section = "form">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <input type="text" id="username" name="username" value="${username}" autocomplete="username"
+                   readonly="readonly" style="display:none;"/>
+            <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}"
+                           autofocus autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('password')>
+                        <span id="input-error-password" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                        </span>
+                    </#if>
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password-confirm" name="password-confirm"
+                           class="${properties.kcInputClass!}"
+                           autocomplete="new-password"
+                           aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('password-confirm')>
+                        <span id="input-error-password-confirm" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('password-confirm'))?no_esc}
+                        </span>
+                    </#if>
+
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <@passwordCommons.logoutOtherSessions/>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <#if isAppInitiatedAction??>
+                        <p>
+                            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
+                        </p>
+                        <p>
+                            <a id="cancel-aia" href="${client.baseUrl}/${locale.currentLanguageTag}/${(locale.currentLanguageTag=="en")?then('settings','parametres')}" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" >${msg("doCancel")}</a>
+                        </p>
+                    <#else>
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
+                    </#if>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/login/resources/css/signin.css
+++ b/login/resources/css/signin.css
@@ -257,3 +257,11 @@ p.instruction {
 div.alert-warning.pf-c-alert.pf-m-inline.pf-m-warning {
     line-height: 1.25rem;
 }
+
+.alert-info {
+    margin-top: 0.75rem;
+}
+
+#logout-sessions {
+    margin-top: 7px;
+}


### PR DESCRIPTION
For https://github.com/OHCRN/platform/issues/1092

- Overrides default [login-update-password template](https://github.com/keycloak/keycloak/blob/release/22.0/themes/src/main/resources/theme/base/login/login-update-password.ftl). Changes "Cancel" button to link element, navigates back to consent-ui Settings page with no changes applied. Settings URL uses correct path from translated route names
- Minor style changes for update password forms
