### PR TITLE
add password-commons template

### DIFF
--- a/login/password-commons.ftl
+++ b/login/password-commons.ftl
@@ -1,0 +1,12 @@
+<#macro logoutOtherSessions>
+    <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+        <div class="${properties.kcFormOptionsWrapperClass!}">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" id="logout-sessions" name="logout-sessions" value="on" checked>
+                    ${msg("logoutOtherSessions")}
+                </label>
+            </div>
+        </div>
+    </div>
+</#macro>


### PR DESCRIPTION
The local testing for the update password flow theme changes was done with the `v22.0.5` Bitnami Keycloak image, but `ohcrn-dev` is using `v22.0.1`. Looks like the latter requires the `password-commons.ftl` file be explicitly defined in the folder with the `login-update-password.ftl` template, so adding in this PR. We may be able to remove this extra file when we update the Keycloak version in our deployed envs.