### PR TITLE
💄 1074 - add resend mfa code text

### DIFF
--- a/login/template.ftl
+++ b/login/template.ftl
@@ -121,6 +121,7 @@
                     </#if>
 
             <#nested "form">
+            <#nested "resend">
 
             <#if auth?has_content && auth.showTryAnotherWayLink()>
                 <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post">


### PR DESCRIPTION
The resend was mistakenly removed in the [Keycloak v26 upgrade changes](https://github.com/OHCRN/keycloak-theme/pull/12), restoring.