### PR TITLE
1074 - add custom class on info text to fix spacing on reset password form

### DIFF
--- a/login/resources/css/signin.css
+++ b/login/resources/css/signin.css
@@ -208,6 +208,9 @@ a#kc-current-locale-link::after {
 /* login only */
 #kc-info {
     margin: 0px -30px -30px;
+    &.login-info-text {
+        margin: 0px -40px;
+    }
 }
 
 /* register only */

--- a/login/template.ftl
+++ b/login/template.ftl
@@ -136,7 +136,7 @@
             <#nested "socialProviders">
 
             <#if displayInfo>
-                <div id="kc-info" class="${properties.kcSignUpClass!}">
+                <div id="kc-info" class="${properties.kcSignUpClass!} login-info-text">
                     <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
                         <#nested "info">
                     </div>


### PR DESCRIPTION
Fixes the spacing between the default reset password info text and the mobile phone info text on the Reset Password form.