### PR TITLE
💄 #1532: Add password requirements to update/forgot password screen

### DIFF
--- a/login/login-update-password.ftl
+++ b/login/login-update-password.ftl
@@ -59,6 +59,17 @@
                 </div>
             </div>
 
+            <div class="password-requirements">
+                <h4>Password must have:</h4>
+                <ul>
+                    <li>At least one lowercase</li>
+                    <li>At least one uppercase</li>
+                    <li>At least 15 characters</li>
+                    <li>At least one number</li>
+                    <li>At least one special character</li>
+                </ul>
+            </div>
+
             <div class="${properties.kcFormGroupClass!}">
                 <@passwordCommons.logoutOtherSessions/>
 

--- a/login/resources/css/signin.css
+++ b/login/resources/css/signin.css
@@ -312,3 +312,43 @@ button.pf-c-button.pf-m-control  {
     }
   }
 }
+
+.password-requirements {
+  margin: 1rem 0;
+  padding: 0;
+}
+
+.password-requirements h4 {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #282A35;
+  margin: 0 0 0.5rem 1.25rem;
+  @media screen and (max-width: 480px) {
+    font-size: 0.75rem;
+  }
+}
+
+.password-requirements ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.password-requirements li {
+  font-size: 0.8rem;
+  margin: -0.25rem 1.75rem;
+  color: #282A35;
+  padding-left: 1rem;
+  position: relative;
+  @media screen and (max-width: 480px) {
+    font-size: 0.7rem;
+  }
+}
+
+.password-requirements li::before {
+  content: "•";
+  color: #282A35;
+  font-weight: bold;
+  position: absolute;
+  left: 0;
+}


### PR DESCRIPTION
## Ticket: [#1532](https://github.com/OHCRN/platform/issues/1532)

## Changes made
Added `password-requirements` div to `login-update-password.ftl` and implement the necessary css changes to the `signin.css` file.

### Testing notes
- verified that there is no password requirements in the regular login page for crc/consent ui and email verification page for consent ui.